### PR TITLE
Implement mirrordamage command

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/ArmorStandMirrorManager.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/ArmorStandMirrorManager.java
@@ -28,6 +28,7 @@ public class ArmorStandMirrorManager {
         stand.setMarker(true);      // keine Hitbox
         stand.setGravity(false);
         stand.setSilent(true);
+        stand.setInvulnerable(true); // kann nicht zerstört werden
         // Rüstung kopieren
         stand.getEquipment().setArmorContents(player.getInventory().getArmorContents());
 

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorCleanupListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorCleanupListener.java
@@ -1,0 +1,27 @@
+package de.elia.cameraplugin.mirrordamage;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+
+public class MirrorCleanupListener implements Listener {
+
+    private final ArmorStandMirrorManager manager;
+
+    public MirrorCleanupListener(ArmorStandMirrorManager manager) {
+        this.manager = manager;
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        manager.removeMirror(event.getPlayer());
+    }
+
+    @EventHandler
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        manager.removeMirror(player);
+    }
+}

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamageCommand.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamageCommand.java
@@ -6,13 +6,13 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 /**
- * Befehl /damgesarmor – toggelt pro Spieler den Test‑ArmorStand.
+ * Befehl /mirrordamage (Alias /md) – toggelt pro Spieler den Test‑ArmorStand.
  */
-public class DamgesArmorCommand implements CommandExecutor {
+public class MirrorDamageCommand implements CommandExecutor {
 
     private final ArmorStandMirrorManager manager;
 
-    public DamgesArmorCommand(ArmorStandMirrorManager manager) {
+    public MirrorDamageCommand(ArmorStandMirrorManager manager) {
         this.manager = manager;
     }
 

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
@@ -2,6 +2,12 @@ package de.elia.cameraplugin.mirrordamage;
 
 import org.bukkit.plugin.java.JavaPlugin;
 
+// Neue Listener und Command-Klasse
+import de.elia.cameraplugin.mirrordamage.MirrorDamageCommand;
+import de.elia.cameraplugin.mirrordamage.MirrorCleanupListener;
+import de.elia.cameraplugin.mirrordamage.DamageTransferListener;
+import de.elia.cameraplugin.mirrordamage.ArmorStandMirrorManager;
+
 public class MirrorDamagePlugin extends JavaPlugin {
 
     private ArmorStandMirrorManager mirrorManager;
@@ -12,8 +18,9 @@ public class MirrorDamagePlugin extends JavaPlugin {
         this.mirrorManager = new ArmorStandMirrorManager(this);
 
         getServer().getPluginManager().registerEvents(new DamageTransferListener(mirrorManager), this);
-        // Command /damgesarmor
-        getCommand("damgesarmor").setExecutor(new DamgesArmorCommand(mirrorManager));
+        getServer().getPluginManager().registerEvents(new MirrorCleanupListener(mirrorManager), this);
+        // Command /mirrordamage (alias /md)
+        getCommand("mirrordamage").setExecutor(new MirrorDamageCommand(mirrorManager));
 
         getLogger().info("MirrorDamage aktiviert");
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,11 +5,12 @@ api-version: 1.21
 author: YourName
 
 commands:
-  damgesarmor:
+  mirrordamage:
+    aliases: md
     description: Spawn/entfernt deinen Test‑ArmorStand
     usage: /<command>
 
 permissions:
   mirrordamage.toggle:
-    description: Erlaubt das Nutzen von /damgesarmor
+    description: Erlaubt das Nutzen von /mirrordamage
     default: true


### PR DESCRIPTION
## Summary
- rename `/damgesarmor` command to `/mirrordamage` with `/md` alias
- prevent spawned mirror ArmorStands from being destroyed
- remove mirrors on player quit or death

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68746f68c6b883229f321a83f8bafa2a