### PR TITLE
Fix mirror armor stand damage transfer

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
@@ -1,5 +1,6 @@
 package de.elia.cameraplugin.mirrordamage;
 
+import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -9,34 +10,48 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.projectiles.ProjectileSource;
 
 /**
- * Listener that prevents players from damaging themselves.
+ * Transfers damage from mirror armor stands to their players
+ * and prevents players from hurting themselves.
  */
 public class DamageTransferListener implements Listener {
 
+    private final ArmorStandMirrorManager mirrorManager;
+
     public DamageTransferListener(ArmorStandMirrorManager mirrorManager) {
-        // Currently unused but kept for future functionality
+        this.mirrorManager = mirrorManager;
     }
 
     @EventHandler
     public void onEntityDamageByEntity(EntityDamageByEntityEvent event) {
         Entity target = event.getEntity();
-        if (!(target instanceof Player victim)) {
-            return;
-        }
 
-        Player attacker = null;
-        Entity damager = event.getDamager();
-        if (damager instanceof Player p) {
-            attacker = p;
-        } else if (damager instanceof Projectile projectile) {
-            ProjectileSource source = projectile.getShooter();
-            if (source instanceof Player p) {
-                attacker = p;
+        // Mirror armor stand hit? Transfer damage to owning player.
+        if (target instanceof ArmorStand stand) {
+            Player owner = mirrorManager.getPlayer(stand);
+            if (owner != null) {
+                event.setCancelled(true); // keep stand intact
+                double damage = event.getFinalDamage();
+                owner.damage(damage, event.getDamager());
+                return;
             }
         }
 
-        if (attacker != null && attacker.getUniqueId().equals(victim.getUniqueId())) {
-            event.setCancelled(true);
+        // Cancel self-inflicted damage
+        if (target instanceof Player victim) {
+            Player attacker = null;
+            Entity damager = event.getDamager();
+            if (damager instanceof Player p) {
+                attacker = p;
+            } else if (damager instanceof Projectile projectile) {
+                ProjectileSource source = projectile.getShooter();
+                if (source instanceof Player p) {
+                    attacker = p;
+                }
+            }
+
+            if (attacker != null && attacker.getUniqueId().equals(victim.getUniqueId())) {
+                event.setCancelled(true);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep mirror armor stand intact when hit
- deal the damage to its owning player instead
- retain self-damage prevention logic

## Testing
- `mvn -q -DskipTests package` *(fails: Plugin resolution requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6874796849f08322b987c69fb7343c46