### PR TITLE
Fix anvil damage transfer

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
@@ -37,7 +37,11 @@ public class VillagerMirrorManager {
         villager.setInvisible(true);
         villager.setAI(false);
         villager.setSilent(true);
-        villager.setInvulnerable(true); // keep the villager alive
+        // The damage transfer listener cancels any incoming damage,
+        // so the villager doesn't need to be invulnerable. Keeping it
+        // vulnerable allows events like falling anvils to trigger and
+        // be redirected to the player.
+        villager.setInvulnerable(false);
 
         villager.getEquipment().setArmorContents(player.getInventory().getArmorContents());
 


### PR DESCRIPTION
## Summary
- remove invulnerability from mirror villager so falling anvils trigger damage events

## Testing
- `mvn -q package` *(fails: could not resolve maven-resources-plugin)*
- `mvn -q test` *(fails: could not resolve maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6874a4cda7348322b1f8b735b4448434