### PR TITLE
Add potion effect transfer from arrows

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
@@ -32,8 +32,18 @@ public class DamageTransferListener implements Listener {
             Player owner = mirrorManager.getPlayer(mirror);
             if (owner != null) {
                 event.setCancelled(true); // keep villager intact
+
+                // Transfer potion effects from tipped arrows
+                Entity damager = event.getDamager();
+                if (damager instanceof Arrow arrow) {
+                    arrow.getBasePotionType().getPotionEffects()
+                            .forEach(effect -> owner.addPotionEffect(effect, true));
+                    arrow.getCustomEffects()
+                            .forEach(effect -> owner.addPotionEffect(effect, true));
+                }
+
                 double damage = event.getFinalDamage();
-                owner.damage(damage, event.getDamager());
+                owner.damage(damage, damager);
                 return;
             }
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: MirrorDamage
 main: de.elia.cameraplugin.mirrordamage.MirrorDamagePlugin
-version: 1.1.0
+version: 1.2.0
 api-version: 1.21
 author: YourName
 


### PR DESCRIPTION
## Summary
- apply potion effects from tipped arrows when the mirror villager is hit
- bump plugin version to 1.2.0

## Testing
- `mvn -q package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin:2.6 from/to central)*

------
https://chatgpt.com/codex/tasks/task_e_6874ae5fcee4832292c5d1227be1eb2a