### PR TITLE
Implement inventory storage and armor durability option

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorCleanupListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorCleanupListener.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import de.elia.cameraplugin.mirrordamage.VillagerMirrorManager;
@@ -18,12 +19,17 @@ public class MirrorCleanupListener implements Listener {
 
     @EventHandler
     public void onPlayerQuit(PlayerQuitEvent event) {
-        manager.removeMirror(event.getPlayer());
+        manager.removeMirror(event.getPlayer(), VillagerMirrorManager.ReturnMode.KEEP);
     }
 
     @EventHandler
     public void onPlayerDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();
-        manager.removeMirror(player);
+        manager.removeMirror(player, VillagerMirrorManager.ReturnMode.DROP);
+    }
+
+    @EventHandler
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        manager.restoreInventory(event.getPlayer());
     }
 }

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamageCommand.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamageCommand.java
@@ -25,7 +25,7 @@ public class MirrorDamageCommand implements CommandExecutor {
             return true;
         }
 
-        if (manager.removeMirror(p)) {
+        if (manager.removeMirror(p, VillagerMirrorManager.ReturnMode.RESTORE)) {
             p.sendMessage("§aDein Test‑Villager wurde entfernt.");
         } else {
             manager.spawnMirror(p);

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
@@ -14,10 +14,11 @@ public class MirrorDamagePlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        saveDefaultConfig();
         // Manager instanziieren & Listener + Command registrieren
         this.mirrorManager = new VillagerMirrorManager(this);
 
-        getServer().getPluginManager().registerEvents(new DamageTransferListener(mirrorManager), this);
+        getServer().getPluginManager().registerEvents(new DamageTransferListener(mirrorManager, this), this);
         getServer().getPluginManager().registerEvents(new MirrorCleanupListener(mirrorManager), this);
         // Command /mirrordamage (alias /md)
         getCommand("mirrordamage").setExecutor(new MirrorDamageCommand(mirrorManager));

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Villager;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
 import java.util.HashMap;
@@ -20,6 +21,13 @@ public class VillagerMirrorManager {
 
     private final Plugin plugin;
     private final Map<UUID, UUID> villagerToPlayer = new HashMap<>();
+    private final Map<UUID, ItemStack[]> savedInventories = new HashMap<>();
+
+    public enum ReturnMode {
+        RESTORE,
+        DROP,
+        KEEP
+    }
 
     public VillagerMirrorManager(Plugin plugin) {
         this.plugin = plugin;
@@ -30,7 +38,7 @@ public class VillagerMirrorManager {
      * player's armour.
      */
     public void spawnMirror(Player player) {
-        removeMirror(player);  // ensure only one exists
+        removeMirror(player, ReturnMode.RESTORE);
 
         Location loc = player.getLocation();
         Villager villager = (Villager) player.getWorld().spawnEntity(loc, EntityType.VILLAGER);
@@ -40,6 +48,11 @@ public class VillagerMirrorManager {
         villager.setInvulnerable(true); // keep the villager alive
 
         villager.getEquipment().setArmorContents(player.getInventory().getArmorContents());
+
+        ItemStack[] contents = player.getInventory().getContents();
+        savedInventories.put(player.getUniqueId(), contents);
+        player.getInventory().clear();
+        player.updateInventory();
 
         villagerToPlayer.put(villager.getUniqueId(), player.getUniqueId());
     }
@@ -56,7 +69,7 @@ public class VillagerMirrorManager {
     }
 
     /** Entfernt den Mirror‑Villager eines Spielers. @return true wenn einer entfernt wurde */
-    public boolean removeMirror(Player player) {
+    public boolean removeMirror(Player player, ReturnMode mode) {
         boolean[] removed = {false};
         villagerToPlayer.entrySet().removeIf(entry -> {
             if (entry.getValue().equals(player.getUniqueId())) {
@@ -67,7 +80,39 @@ public class VillagerMirrorManager {
             }
             return false;
         });
+
+        if (removed[0]) {
+            if (mode == ReturnMode.RESTORE) {
+                restoreInventory(player);
+            } else if (mode == ReturnMode.DROP) {
+                dropInventory(player);
+            }
+        }
+
         return removed[0];
+    }
+
+    public boolean removeMirror(Player player) {
+        return removeMirror(player, ReturnMode.RESTORE);
+    }
+
+    public void restoreInventory(Player player) {
+        ItemStack[] contents = savedInventories.remove(player.getUniqueId());
+        if (contents != null) {
+            player.getInventory().setContents(contents);
+            player.updateInventory();
+        }
+    }
+
+    private void dropInventory(Player player) {
+        ItemStack[] contents = savedInventories.remove(player.getUniqueId());
+        if (contents == null) return;
+        Location loc = player.getLocation();
+        for (ItemStack item : contents) {
+            if (item != null && item.getType().isItem()) {
+                player.getWorld().dropItemNaturally(loc, item);
+            }
+        }
     }
 
     /** Für onDisable */

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,1 @@
+armor-takes-damage: true


### PR DESCRIPTION
## Summary
- add config with `armor-takes-damage`
- store player's inventory when spawning a mirror villager
- restore, drop, or keep inventory based on player events
- degrade armor durability when mirror takes damage
- load config and register new listeners

## Testing
- `mvn -q -DskipTests package` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687526aaa3b4832289a815a3ace05224