### PR TITLE
Add armor durability loss when mirror villager hit

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
@@ -141,9 +141,28 @@ public class DamageTransferListener implements Listener {
 
     private void damagePlayerArmor(Player player, EntityDamageEvent.DamageCause cause) {
         if (!damageArmor || !durabilityCauses.contains(cause)) return;
-        ItemStack[] armor = player.getInventory().getArmorContents();
-        for (int i = 0; i < armor.length; i++) {
-            ItemStack item = armor[i];
+
+        // damage currently equipped armour
+        damageItems(player.getInventory().getArmorContents());
+
+        // also damage armour stored on a mirror villager
+        Villager mirror = mirrorManager.getMirror(player);
+        if (mirror != null) {
+            damageItems(mirror.getEquipment().getArmorContents());
+
+            // keep stored inventory in sync if it was cloned
+            ItemStack[] stored = mirrorManager.getStoredInventory(player);
+            if (stored != null && stored.length >= 40) {
+                ItemStack[] mirrorArmor = mirror.getEquipment().getArmorContents();
+                for (int i = 0; i < mirrorArmor.length && (36 + i) < stored.length; i++) {
+                    stored[36 + i] = mirrorArmor[i];
+                }
+            }
+        }
+    }
+
+    private void damageItems(ItemStack[] armor) {
+        for (ItemStack item : armor) {
             if (item == null) continue;
             var meta = item.getItemMeta();
             if (meta instanceof Damageable dmg) {

--- a/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/VillagerMirrorManager.java
@@ -34,8 +34,10 @@ public class VillagerMirrorManager {
     public void spawnMirror(Player player) {
         removeMirror(player);  // ensure only one exists
 
-        // store and clear inventory
-        storedInventories.put(player.getUniqueId(), player.getInventory().getContents());
+        // store inventory (including armour) and clear it
+        ItemStack[] contents = player.getInventory().getContents();
+        storedInventories.put(player.getUniqueId(), contents);
+        ItemStack[] armor = player.getInventory().getArmorContents();
         player.getInventory().clear();
 
         Location loc = player.getLocation();
@@ -49,7 +51,9 @@ public class VillagerMirrorManager {
         // be redirected to the player.
         villager.setInvulnerable(false);
 
-        villager.getEquipment().setArmorContents(player.getInventory().getArmorContents());
+        // give the villager the player's armour so durability changes can be
+        // reflected back later
+        villager.getEquipment().setArmorContents(armor);
 
         villagerToPlayer.put(villager.getUniqueId(), player.getUniqueId());
     }
@@ -63,6 +67,22 @@ public class VillagerMirrorManager {
     /** Prüft, ob bereits ein Mirror‑Villager existiert. */
     public boolean hasMirror(Player player) {
         return villagerToPlayer.containsValue(player.getUniqueId());
+    }
+
+    /** Returns the mirror villager for the given player or {@code null}. */
+    public Villager getMirror(Player player) {
+        for (var entry : villagerToPlayer.entrySet()) {
+            if (entry.getValue().equals(player.getUniqueId())) {
+                Entity e = Bukkit.getEntity(entry.getKey());
+                if (e instanceof Villager v) return v;
+            }
+        }
+        return null;
+    }
+
+    /** Returns the stored inventory for the player if one exists. */
+    public ItemStack[] getStoredInventory(Player player) {
+        return storedInventories.get(player.getUniqueId());
     }
 
     /** Entfernt den Mirror‑Villager eines Spielers. @return true wenn einer entfernt wurde */


### PR DESCRIPTION
## Summary
- ensure mirror villager uses player's armour
- expose mirror lookup helpers
- damage stored/mirror armour when the villager takes damage

## Testing
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68758fb70c948322aa5430b02787c636