### PR TITLE
Fix double durability damage

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
@@ -86,9 +86,13 @@ public class DamageTransferListener implements Listener {
     /**
      * Transfer any damage the mirror villager receives to its player.
      */
-    @EventHandler
+    @EventHandler(ignoreCancelled = true)
     public void onMirrorDamage(EntityDamageEvent event) {
         if (!(event.getEntity() instanceof Villager mirror)) return;
+
+        // Entity-caused damage is handled in onEntityDamageByEntity to avoid
+        // double armour durability loss.
+        if (event instanceof EntityDamageByEntityEvent) return;
 
         Player owner = mirrorManager.getPlayer(mirror);
         if (owner == null) return;


### PR DESCRIPTION
## Summary
- prevent the mirror villager damage handler from running twice by ignoring `EntityDamageByEntityEvent`
- this halves the armour durability loss so items no longer lose double durability

## Testing
- `mvn -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875bcb2d06c8322a25ae00b0f545995