### PR TITLE
Remove villager-gravity config option

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/MirrorDamagePlugin.java
@@ -16,7 +16,7 @@ public class MirrorDamagePlugin extends JavaPlugin {
     public void onEnable() {
         saveDefaultConfig();
         boolean damageArmor = getConfig().getBoolean("damage-armor", true);
-        boolean villagerGravity = getConfig().getBoolean("villager-gravity", true);
+        boolean villagerGravity = true; // villager-gravity is now always enabled
         // Manager instanziieren & Listener + Command registrieren
         this.mirrorManager = new VillagerMirrorManager(this, villagerGravity);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,1 @@
 damage-armor: true
-villager-gravity: true


### PR DESCRIPTION
## Summary
- drop the `villager-gravity` entry from the default config
- hardcode villager gravity to `true`

## Testing
- `mvn -q -DskipTests compile` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_687632a414bc8322906a5ff0c69a2973