### PR TITLE
Fix lightning transformation for mirror villagers

### DIFF
--- a/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
+++ b/src/main/java/de/elia/cameraplugin/mirrordamage/DamageTransferListener.java
@@ -12,6 +12,8 @@ import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.projectiles.ProjectileSource;
+import org.bukkit.event.entity.EntityTransformEvent;
+import org.bukkit.entity.Witch;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.Damageable;
@@ -130,6 +132,22 @@ public class DamageTransferListener implements Listener {
             if (attacker != null && attacker.getUniqueId().equals(victim.getUniqueId())) {
                 event.setCancelled(true);
             }
+        }
+    }
+
+    /**
+     * Prevent mirror villagers from turning into witches when struck by lightning.
+     */
+    @EventHandler(ignoreCancelled = true)
+    public void onVillagerTransform(EntityTransformEvent event) {
+        if (!(event.getEntity() instanceof Villager villager)) return;
+
+        // only apply to mirror villagers
+        if (mirrorManager.getPlayer(villager) == null) return;
+
+        if (event.getTransformReason() == EntityTransformEvent.TransformReason.LIGHTNING &&
+                event.getTransformedEntity() instanceof Witch) {
+            event.setCancelled(true);
         }
     }
 


### PR DESCRIPTION
## Summary
- keep mirror villagers from transforming into witches when struck by lightning
- still mirror lightning damage to the owning player

## Testing
- `mvn -q -DskipTests package` *(fails: plugin download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68764d5a1d808322ac4208b6e15546c1